### PR TITLE
remove WORKDIR from docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:11-jre-slim
 
-ENV LIQUIBASE_VERSION 4.13.0
+ARG LIQUIBASE_VERSION=4.13.0
 
 RUN apt update && \
     apt install curl -y && \
@@ -9,7 +9,5 @@ RUN apt update && \
     curl -L https://github.com/liquibase/liquibase/releases/download/v${LIQUIBASE_VERSION}/liquibase-${LIQUIBASE_VERSION}.tar.gz | tar -xzf-
 
 ENV LIQUIBASE_HOME /opt/liquibase
-
-WORKDIR /opt/liquibase
 
 ENTRYPOINT ["/opt/liquibase/liquibase"]

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Make the following changes in the application helm chart:
     dependencies:
       - name: db-schema-manager
         repository: https://storage.googleapis.com/hypertrace-helm-charts
-        version: 0.1.0
+        version: 0.1.1
         condition: db-schema-manager.enabled
    ```
 


### PR DESCRIPTION
Liquibase use current directory as the base of search path for changelogs file.

```
Starting Liquibase at 06:55:40 (version 4.13.0 #3391 built at 2022-07-06 12:07+0000)
Liquibase Version: 4.13.0
Liquibase Community 4.13.0 by Liquibase

Liquibase Community detected and ignored the following environment variables:
- LIQUIBASE_VERSION
To configure Liquibase with environment variables requires a Liquibase Pro or Liquibase Labs license. Get a free trial at https://liquibase.com/trial. Options include the liquibase.licenseKey in the defaults file, adding a flag in the CLI, and more. Learn more at https://docs.liquibase.com.

Unexpected error running Liquibase: The file /etc/liquibase/changelogs/changelog.sql was not found in the configured search path:
    - /opt/liquibase/.
    - /opt/liquibase/internal/lib
    - /opt/liquibase/internal/lib/commons-collections4.jar
    - /opt/liquibase/internal/lib/commons-lang3.jar
    - /opt/liquibase/internal/lib/commons-text.jar
    - /opt/liquibase/internal/lib/connector-api.jar
    - /opt/liquibase/internal/lib/h2.jar
    - /opt/liquibase/internal/lib/hsqldb.jar
    - /opt/liquibase/internal/lib/jaxb-api.jar
    - /opt/liquibase/internal/lib/jaxb-core.jar
    - /opt/liquibase/internal/lib/jaxb-runtime.jar
    - /opt/liquibase/internal/lib/jaybird.jar
    - /opt/liquibase/internal/lib/jcc.jar
    - /opt/liquibase/internal/lib/mariadb-java-client.jar
    - /opt/liquibase/internal/lib/mssql-jdbc.jar
    - /opt/liquibase/internal/lib/ojdbc8.jar
    - /opt/liquibase/internal/lib/opencsv.jar
    - /opt/liquibase/internal/lib/picocli.jar
    - /opt/liquibase/internal/lib/postgresql.jar
    - /opt/liquibase/internal/lib/snakeyaml.jar
    - /opt/liquibase/internal/lib/snowflake-jdbc.jar
    - /opt/liquibase/internal/lib/sqlite-jdbc.jar
    - /opt/liquibase/lib
    - /opt/liquibase/liquibase.jar
More locations can be added with the 'searchPath' parameter.

For more information, please use the --log-level flag
```